### PR TITLE
Define name for Runtime

### DIFF
--- a/lib/alaska.rb
+++ b/lib/alaska.rb
@@ -69,6 +69,10 @@ class Alaska < ExecJS::Runtime
     @benchmarks = []
   end
 
+  def name
+    "Alaska"
+  end
+
   def connection
     @port ||= begin
       srand


### PR DESCRIPTION
`ExecJS::Runtime` definition includes a name method. The base class just raises `NotImplementedError`, but all the built-in runtimes override this to return the runtime name.