### PR TITLE
Encode JS errors as JSON

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,24 @@
 PATH
   remote: .
   specs:
-    alaska (0.0.1)
+    alaska (0.0.4)
       execjs
 
 GEM
   remote: https://rubygems.org/
   specs:
     execjs (2.3.0)
+    minitest (5.5.1)
+    power_assert (0.2.2)
+    rake (10.4.2)
+    test-unit (3.0.8)
+      power_assert
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   alaska!
+  minitest (~> 5.5.1)
+  rake (~> 10.4)
+  test-unit

--- a/alaska.gemspec
+++ b/alaska.gemspec
@@ -11,4 +11,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency 'execjs'
+  s.add_development_dependency 'rake', '~> 10.4'
+  s.add_development_dependency 'minitest', '~> 5.5.1'
 end

--- a/alaska.js
+++ b/alaska.js
@@ -45,7 +45,7 @@ var server = http.createServer(function(req, res) {
         }
       }
     } catch(err) {
-      webPrint(res, '["err", "' + (err.toString()) + '"]');
+      webPrint(res, JSON.stringify(["err", err.toString()]));
     }
   });
 });

--- a/test/test_alaska.rb
+++ b/test/test_alaska.rb
@@ -14,6 +14,12 @@ describe Alaska do
     js_result.must_equal 42
   end
 
+  it "raises an ExecJS::ProgramError on error" do
+    lambda {
+      @alaska_context.eval("(function() { throw new Error('foo\\nbar', 0, 'test.js'); })()")
+    }.must_raise(ExecJS::ProgramError)
+  end
+
   it "requires js to be in a self-executing function" do
     js_result = -1
 

--- a/test/test_alaska.rb
+++ b/test/test_alaska.rb
@@ -1,6 +1,5 @@
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'test/unit'
 require 'alaska'
 
 describe Alaska do


### PR DESCRIPTION
I ran the Uglifier test suite with Alaska and got a failure when throwing an exception inside JS code. The error message is not properly JSONified, so if there are quotes or line breaks in the exception, a JSON::ParseError is thrown instead of ExecJS::ProgramError.