### PR TITLE
detect all usr bin nodes from PATH

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    alaska (1.1.0)
+    alaska (1.2.0)
       execjs (~> 2.7)
 
 GEM
@@ -18,3 +18,6 @@ DEPENDENCIES
   alaska!
   minitest (~> 5.5)
   rake (~> 10.4)
+
+BUNDLED WITH
+   1.13.6

--- a/alaska.gemspec
+++ b/alaska.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'alaska'
-  s.version     = '1.1.0'
-  s.date        = '2016-05-28'
+  s.version     = '1.2.0'
+  s.date        = '2016-12-08'
   s.summary     = "persistent ExecJS runtime"
   s.description = "uses a single shared nodejs process to handle ExecJS::Runtime evaluation"
   s.authors     = ["Jon Bardin", "Stephen Grider", "Ville Lautanala", "Giovanni Bonetti"]

--- a/lib/alaska/runtime.rb
+++ b/lib/alaska/runtime.rb
@@ -23,8 +23,14 @@ module Alaska
     end
 
     def available?
-      #NOTE: this is brittle in terms of cross platform detection of node executable
-      `which #{@nodejs_cmd}`.strip.length > 0 # this must return true to be enabled
+      ENV["PATH"].split(":").detect do |path|
+        %w{
+          nodejs
+          node
+        }.detect do |node|
+          File.exist?(File.join(path, node)) || File.symlink?(File.join(path, node))
+        end
+      end
     end
 
     def deprecated?


### PR DESCRIPTION
This will save the overhead of using `which` and child-process, at the cost of a slightly slower lookup because of the naivety of the search mechanism... could be improved later